### PR TITLE
Fix height problem for Firefox

### DIFF
--- a/ui/components/BarChart/BarChart.scss
+++ b/ui/components/BarChart/BarChart.scss
@@ -9,6 +9,7 @@
   &__bar {
     position: relative;
     width: 30px;
+    height: 100%;
     padding: 0 8px;
     cursor: pointer;
 
@@ -36,6 +37,7 @@
     display: flex;
     flex-direction: column-reverse;
     width: 100%;
+    height: 100%;
 
     &:hover {
       .min {


### PR DESCRIPTION
Firefox needs this extra style for the charts to work.

Tested on Chrome as well.